### PR TITLE
Nmb 19 add vetoing

### DIFF
--- a/src/components/Feed/index.js
+++ b/src/components/Feed/index.js
@@ -60,7 +60,7 @@ function Feed() {
       <div className={styles.cardWrapper}>
         {
           news.map((newsItem) => (
-            <Card key={newsItem.title+newsItem.date} className={cx({ [styles.tile]: view === 'tile', [styles.list]: view === 'list' })}>
+            <Card key={newsItem.title + newsItem.date} className={cx({ [styles.tile]: view === 'tile', [styles.list]: view === 'list' })}>
               <h3 className={styles.cardTitle}>{newsItem.title}</h3>
               <p className={styles.cardInfo}>
                 {newsItem.date}

--- a/src/components/Legislation/LegislationView/index.js
+++ b/src/components/Legislation/LegislationView/index.js
@@ -2,14 +2,17 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { legislationActions } from '../../../redux/actions';
-import { legislationSelectors } from '../../../redux/selectors';
+import { blockchainSelectors, legislationSelectors } from '../../../redux/selectors';
 import Card from '../../Card';
+import { castVetoForLegislation, revertVetoForLegislation } from '../../../api/nodeRpcCall';
 
 import styles from './styles.module.scss';
+import Button from '../../Button/Button';
 
 const LegislationView = () => {
   const { tier } = useParams();
   const dispatch = useDispatch();
+  const userWalletAddress = useSelector(blockchainSelectors.userWalletAddressSelector);
 
   useEffect(() => {
     dispatch(legislationActions.getLegislation.call(tier));
@@ -19,8 +22,33 @@ const LegislationView = () => {
 
   if (!legislation[tier]) return 'Loading...';
 
+  console.log(legislation);
+
   return legislation[tier].map((l) => (
-    <Card className={styles.legislationCard} title={`#${l.index}`} key={l.index}>{l.content}</Card>
+    <Card className={styles.legislationCard} title={`#${l.index}`} key={l.index}>
+      <div className={styles.legislationInfoContainer}>
+        <div className={styles.legislationContent}>
+          {l.content}
+        </div>
+        <div className={styles.vetoContent}>
+          <div className={styles.vetoInfo}>
+            <div>
+              <b>{l?.vetos?.length}</b>
+              {' '}
+              / xyz
+            </div>
+            <div>Citizens vetoed</div>
+          </div>
+          <div>
+            {
+              l?.vetos?.includes(userWalletAddress)
+                ? <Button small red onClick={() => revertVetoForLegislation(tier, l.index, userWalletAddress)}>Revert Veto</Button>
+                : <Button small primary onClick={() => castVetoForLegislation(tier, l.index, userWalletAddress)}>Cast Veto</Button>
+            }
+          </div>
+        </div>
+      </div>
+    </Card>
   ));
 };
 

--- a/src/components/Legislation/LegislationView/styles.module.scss
+++ b/src/components/Legislation/LegislationView/styles.module.scss
@@ -1,3 +1,24 @@
 .legislationCard {
     margin-bottom: 15px;
 }
+.legislationInfoContainer {
+    flex-direction: row;
+    display: flex;
+}
+.legislationContent {
+    align-items: flex-start;
+    flex: 4;
+    display: flex;
+}
+.vetoContent {
+    align-items: flex-end;
+    flex: 1;
+    display: flex;
+}
+.vetoInfo {
+    display: flex;
+    align-items: center;
+    justify-items: center;
+    flex-direction: column;
+    margin-right: 1rem;
+}


### PR DESCRIPTION
Adds ability to veto and revert veto.

This is a bit unoptimized, specifically getLegislation in noderpc edits, because to get vetos, blockchain stores all adresses that vetoed it, we need only the number of vetoes and to see if user did veto.
But to get this, since it doesnt track numbers of vetos directly, we need to use entries (api.query.liberlandLegislation.vetos.entries)

which cannot be combined with .multi, so there are many api queries. Left a blockchain task to optimize this.

Also, doesnt yet have a loading wheel, that will come as a separate task.