### PR TITLE
BLOCKCHAIN-269 - Support multiple wallet extensions installed at the same time

### DIFF
--- a/src/utils/walletHelpers.js
+++ b/src/utils/walletHelpers.js
@@ -52,3 +52,28 @@ export const formatDollarTransaction = (dollars_raw) => formatTransaction(
   'picoLLD',
   dollarDecimals,
 );
+
+export const waitForInjectedWeb3 = async () => {
+  const delay = (time) => new Promise((resolve) => { setTimeout(resolve, time); });
+  const timeout = 5000;
+  const start = Date.now();
+  const interval = 100;
+
+  // wait up to 5s for first extension
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    await delay(interval);
+    if (Date.now() - start > timeout) break;
+    if (window.injectedWeb3) break;
+  }
+
+  // after first extension, debounce new ones
+  let extensions = Object.keys(window.injectedWeb3).length;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    await delay(interval);
+    const newCount = Object.keys(window.injectedWeb3).length;
+    if (extensions === newCount) break;
+    extensions = newCount;
+  }
+};


### PR DESCRIPTION
Fixes race condition. subwallet usually registers faster than polkadot.js, so if we do web3Enable in between, we ignore polkadot.js.
This PR makes sure we wait up to 100ms after each new registered extension, giving polkadot.js time to inject.