### PR TITLE
add automated ICM tokens reading and writing to identity office

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -9,9 +9,9 @@ REACT_APP_ONBOARDER_LLD_FAUCET_ADDRESS='5CSxW2nn4mQckisBziai4wGqQLEdKTUA4Xnt8iy8
 REACT_APP_MAIN_LIBERLAND_WEBSITE='https://liberland.org/'
 REACT_APP_SUBWALLET_LINK='https://mobile.subwallet.app/browser?url=https%3A%2F%2Fblockchain.liberland.org%2F'
 # Edit clientId in SSO links to one setup in local auth db
-REACT_APP_SSO2FA_API_IMPLICIT_LINK='http://localhost:8040/oauth/authorize?response_type=token&client_id=6&redirect_uri=http://localhost:8080/signin'
-REACT_APP_SSO2FA_API_LOGOUT_IMPLICIT_LINK='http://localhost:8040/logout?redirect=http%3A%2F%2Flocalhost%3A8040%2Foauth%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D6%26redirect_uri%3Dhttp%3A%2F%2Flocalhost%3A8080%2Fsignin'
 REACT_APP_SSO_API_CLIENT_ID='5'
+REACT_APP_SSO_API_ADMIN_CLIENT_ID='6'
+REACT_APP_SSO_API_ADMIN_LINK='http://localhost:8080/signin?admin=true'
 
 # Dev Anvil
 REACT_APP_ETHER_CHAIN_ID=31337

--- a/src/api/backend.js
+++ b/src/api/backend.js
@@ -26,9 +26,10 @@ export const getUsersByAddress = async (blockchainAddress) => {
     },
   });
 
-  return data.map(({ uid, merits }) => ({
+  return data.map(({ uid, merits, dollars }) => ({
     uid,
     merits: ethers.utils.parseUnits(merits.toFixed(12), 12),
+    dollars: ethers.utils.parseUnits(dollars.toFixed(12), 12),
   }));
 };
 
@@ -49,6 +50,16 @@ export const maybeGetApprovedEresidency = async () => {
 export const addMeritTransaction = async (userId, amount) => {
   const formattedAmount = ethers.utils.formatUnits(amount, 12);
   await api.post('/merit-transactions', {
+    userId,
+    amount: formattedAmount,
+    source: 'blockchain-fe-app',
+    comment: 'User onboarding on blockchain',
+  });
+};
+
+export const addDollarsTransaction = async (userId, amount) => {
+  const formattedAmount = ethers.utils.formatUnits(amount, 12);
+  await api.post('/dollar-transactions', {
     userId,
     amount: formattedAmount,
     source: 'blockchain-fe-app',

--- a/src/components/AuthComponents/SignIn/index.js
+++ b/src/components/AuthComponents/SignIn/index.js
@@ -23,12 +23,6 @@ function SignIn() {
   const goToLiberlandSignin = () => {
     login();
   };
-  const goToLiberland2FASignin = () => {
-    window.location.replace(process.env.REACT_APP_SSO2FA_API_IMPLICIT_LINK);
-  };
-  const goToLiberland2FASignout = () => {
-    window.location.replace(process.env.REACT_APP_SSO2FA_API_LOGOUT_IMPLICIT_LINK);
-  };
 
   return (
     <div>
@@ -77,12 +71,7 @@ function SignIn() {
 
       </div>
       <div className={styles.twoFAbuttons}>
-        <div onClick={goToLiberland2FASignin}>
-          2fa login
-        </div>
-        <div onClick={goToLiberland2FASignout}>
-          2fa logout
-        </div>
+        <a href={`${process.env.REACT_APP_SSO_API_ADMIN_LINK}`}>admin login</a>
       </div>
     </div>
   );

--- a/src/components/Home/HomeNavigation/index.js
+++ b/src/components/Home/HomeNavigation/index.js
@@ -65,6 +65,7 @@ function HomeNavigation() {
 
   const handleLogout = () => {
     logOut();
+    localStorage.setItem('isAdminLogin', 'true')
     dispatch(authActions.signOut.call(history));
   };
 

--- a/src/components/Modals/OnchainIdentityModal.js
+++ b/src/components/Modals/OnchainIdentityModal.js
@@ -110,7 +110,7 @@ function OnchainIdentityModal({
         placeholder="Email"
       />
       <div className={styles.error}>{errors?.email?.message || errors?.email?.message}</div>
-      <div className={styles.title}>I am or want to become a</div>
+      <div className={styles.title}>I am a</div>
       <SelectInput
         register={register}
         name="onChainIdentity"

--- a/src/components/Offices/Identity/index.js
+++ b/src/components/Offices/Identity/index.js
@@ -15,10 +15,10 @@ import {
 } from '../../../redux/selectors';
 import styles from './styles.module.scss';
 import Table from '../../Table';
-import { parseLegal } from '../../../utils/identityParser';
+import {parseIdentityData, parseLegal} from '../../../utils/identityParser';
 import { isValidSubstrateAddress } from '../../../utils/bridge';
 import {fetchPendingIdentities} from "../../../api/nodeRpcCall";
-import {parseDollars} from "../../../utils/walletHelpers";
+import {parseDollars, parseMerits} from "../../../utils/walletHelpers";
 
 function IdentityForm() {
   const dispatch = useDispatch();
@@ -37,38 +37,46 @@ function IdentityForm() {
     setPendingIdentities(pendingIdentities)
   }
   const onSubmit = ({ account }) => {
+    console.log('submitting')
     dispatch(officesActions.officeGetIdentity.call(account));
   };
   return (
-    <form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
-
+    <div>
       <div>
         {pendingIdentities.map(pendingIdentity => {
-          return (<p>{pendingIdentity.address}</p>)
+          return (<div>{pendingIdentity.address}
+            <button onClick={
+              () => {
+                console.log('fetching')
+                dispatch(officesActions.officeGetIdentity.call(pendingIdentity.address))
+              }}>fetch</button></div>)
         })}
         <Button primary medium onClick={() => doFetchPendingIdentities()}>
           Fetch pending identities
         </Button>
       </div>
 
-      <div className={styles.h3}>Verify citizenship request</div>
+      <form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
+        <div className={styles.h3}>Verify citizenship request</div>
 
-      <TextInput
-        register={register}
-        name="account"
-        placeholder="Candidate's wallet address"
-        validate={(v) => isValidSubstrateAddress(v) || 'Invalid Address'}
-        required
-      />
-      {errors?.account?.message
+        <TextInput
+          register={register}
+          name="account"
+          placeholder="Candidate's wallet address"
+          validate={(v) => isValidSubstrateAddress(v) || 'Invalid Address'}
+          required
+        />
+        {errors?.account?.message
         && <div className={styles.error}>{errors.account.message}</div>}
 
-      <div className={styles.buttonWrapper}>
-        <Button primary medium type="submit">
-          Fetch Identity data
-        </Button>
-      </div>
-    </form>
+        <div className={styles.buttonWrapper}>
+          <Button primary medium type="submit">
+            Fetch Identity data
+          </Button>
+        </div>
+      </form>
+    </div>
+
   );
 }
 
@@ -209,16 +217,12 @@ function TokenTable({ backendMerits, backendDollars }) {
       ]}
       data={[
         {
-          //desc: 'LLM balance',
-          desc: 'Cannot read backend LLM balance',
-          //res: backendMerits ? ethers.utils.formatUnits(backendMerits, 12) : 0,
-          res: ethers.utils.formatUnits(0, 12),
+          desc: 'LLM ICM balance',
+          res: backendMerits ? ethers.utils.formatUnits(backendMerits, 12) : 0,
         },
         {
-          //desc: 'LLD balance',
-          desc: 'Cannot read backend LLD balance',
-          //res: backendDollars ? ethers.utils.formatUnits(backendDollars, 12) : 0,
-          res: ethers.utils.formatUnits(0, 12),
+          desc: 'LLD ICM balance',
+          res: backendDollars ? ethers.utils.formatUnits(backendDollars, 12) : 0,
         },
       ]}
     />
@@ -281,40 +285,15 @@ IdentityTable.propTypes = {
 };
 
 function IdentityInfo() {
-  const dispatch = useDispatch();
   const identity = useSelector(officesSelectors.selectorIdentity);
-  const sender = useSelector(blockchainSelectors.userWalletAddressSelector);
-  const {
-    handleSubmit,
-    formState: { errors },
-    register,
-  } = useForm({
-    mode: 'all',
-  });
-
   if (identity.onchain === null) return null;
   if (identity.onchain.isNone) return <MissingIdentity />;
 
   const onchain = identity.onchain.unwrap();
   const { hash } = onchain.info;
 
-  //const backendMerits = identity.backend?.merits ?? 0;
-  const backendMerits = ethers.utils.parseUnits('0', 12);
-  //const backendDollars = backendMerits?.div(10);
-  const backendDollars = ethers.utils.parseUnits('0', 12);
-
-  const provideJudgementAndSendTokens = (values) => {
-    dispatch(
-      officesActions.provideJudgementAndAssets.call({
-        walletAddress: sender,
-        address: identity.address,
-        uid: identity.backend?.uid,
-        hash,
-        merits: parseDollars(values.amountLLM),
-        dollars: parseDollars(values.amountLLD),
-      }),
-    );
-  };
+  const backendMerits = identity.backend?.merits ?? 0;
+  const backendDollars = identity.backend?.dollars ?? 0;
 
   const judgements = onchain.judgements
     .filter((i) => i[0].eq(0))
@@ -334,28 +313,63 @@ function IdentityInfo() {
           {judgement}
         </div>
       </div>
-      <form onSubmit={handleSubmit(provideJudgementAndSendTokens)}>
-        <TextInput
-          register={register}
-          name="amountLLM"
-          placeholder="Amount LLM"
-          required
-        />
-        <TextInput
-          register={register}
-          name="amountLLD"
-          placeholder="Amount LLD"
-          required
-        />
-        <div className={styles.buttonWrapper}>
-          <Button primary medium type="submit">
-            Provide KnownGood judgement and transfer LLM and LLD
-          </Button>
-        </div>
-      </form>
+     <SubmitForm backendMerits={backendMerits} backendDollars={backendDollars} identity={identity} hash={hash}/>
 
     </>
   );
+}
+
+function SubmitForm({identity, backendMerits, backendDollars, hash}) {
+  const dispatch = useDispatch();
+  const sender = useSelector(blockchainSelectors.userWalletAddressSelector);
+  const defaultValues = {
+    amountLLM: ethers.utils.formatUnits(backendMerits, 12),
+    amountLLD: ethers.utils.formatUnits(backendDollars, 12),
+  };
+  const {
+    handleSubmit,
+    formState: { errors },
+    register,
+  } = useForm({
+    mode: 'all', defaultValues
+  });
+
+
+
+  const provideJudgementAndSendTokens = (values) => {
+    dispatch(
+      officesActions.provideJudgementAndAssets.call({
+        walletAddress: sender,
+        address: identity.address,
+        uid: identity.backend?.uid,
+        hash,
+        merits: parseMerits(values.amountLLM),
+        dollars: parseDollars(values.amountLLD),
+      }),
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit(provideJudgementAndSendTokens)}>
+      <TextInput
+        register={register}
+        name="amountLLM"
+        placeholder="Amount LLM"
+        required
+      />
+      <TextInput
+        register={register}
+        name="amountLLD"
+        placeholder="Amount LLD"
+        required
+      />
+      <div className={styles.buttonWrapper}>
+        <Button primary medium type="submit">
+          Provide KnownGood judgement and transfer LLM and LLD
+        </Button>
+      </div>
+    </form>
+  )
 }
 
 function Identity() {

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,18 @@ const etherConfig = {
     [process.env.REACT_APP_ETHER_CHAIN_ID]: process.env.REACT_APP_ETHER_PROVIDER,
   },
 };
+const adminAuthConfig = {
+  clientId: `${process.env.REACT_APP_SSO_API_ADMIN_CLIENT_ID}`,
+  authorizationEndpoint: `${process.env.REACT_APP_SSO_API}/oauth/authorize`,
+  tokenEndpoint: `${process.env.REACT_APP_SSO_API}/oauth/token`,
+  redirectUri: `${process.env.REACT_APP_SSO_API_ADMIN_LINK}`,
+  scope: 'others:read_write',
+  postLogin: () => {
+    store.dispatch(authActions.verifySession.call());
+    store.dispatch(onBoardingActions.getEligibleForComplimentaryLld.call());
+  },
+  decodeToken: false,
+};
 
 const authConfig = {
   clientId: `${process.env.REACT_APP_SSO_API_CLIENT_ID}`,
@@ -28,10 +40,17 @@ const authConfig = {
   decodeToken: false,
 };
 
+const queryString = window.location.search;
+const urlParams = new URLSearchParams(queryString);
+const isAdminLogin = urlParams.get('admin')
+if(isAdminLogin === 'true') {localStorage.setItem('isAdminLogin', 'true')}
+
+const useAuthConfig = localStorage.getItem('isAdminLogin') === 'true' ? adminAuthConfig : authConfig
+
 ReactDOM.render(
   <DAppProvider config={etherConfig}>
     <Provider store={store}>
-      <AuthProvider authConfig={authConfig}>
+      <AuthProvider authConfig={useAuthConfig} >
         <App />
       </AuthProvider>
     </Provider>

--- a/src/redux/sagas/offices.js
+++ b/src/redux/sagas/offices.js
@@ -19,20 +19,20 @@ import { officesActions } from '../actions';
 import { blockchainWatcher } from './base';
 import { blockchainSelectors } from '../selectors';
 import router from '../../router';
-
+import * as backend from '../../api/backend'
+import {addDollarsTransaction} from "../../api/backend";
 // WORKERS
 
 function* getIdentityWorker(action) {
   try {
     const onchain = yield call(getIdentity, action.payload);
-    /* const backendUsers = yield call(backend.getUsersByAddress, action.payload);
+    const backendUsers = yield call(backend.getUsersByAddress, action.payload);
     if (backendUsers.length > 1) {
       yield put(blockchainActions.setErrorExistsAndUnacknowledgedByUser.success(true));
       yield put(blockchainActions.setError.success({ details: 'More than one user has the same address?' }));
       return;
     }
-    yield put(officesActions.officeGetIdentity.success({ onchain, backend: backendUsers[0] })); */
-    yield put(officesActions.officeGetIdentity.success({ onchain, backend: {} }));
+    yield put(officesActions.officeGetIdentity.success({ onchain, backend: backendUsers[0] }));
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error(e);
@@ -41,9 +41,29 @@ function* getIdentityWorker(action) {
 }
 
 function* provideJudgementAndAssetsWorker(action) {
+  if ((action.payload.merits || action.payload.dollars) && !action.payload.uid) {
+    throw new Error('Tried to transfer LLD or LLM but we have no user id!');
+  }
   yield call(provideJudgementAndAssets, action.payload);
   yield put(officesActions.provideJudgementAndAssets.success());
   yield put(officesActions.officeGetIdentity.call(action.payload.address));
+
+  if (action.payload.merits?.gt(0)) {
+    try {
+      yield call(backend.addMeritTransaction, action.payload.uid, action.payload.merits * -1);
+    } catch (e) {
+      throw new Error(e.response.data.error.message);
+    }
+  }
+
+  if (action.payload.dollars?.gt(0)) {
+    try {
+      yield call(backend.addDollarsTransaction, action.payload.uid, action.payload.dollars * -1);
+    } catch (e) {
+      throw new Error(e.response.data.error.message);
+    }
+  }
+
 }
 
 function* getCompanyRequestWorker(action) {


### PR DESCRIPTION
To add ICM reading and writing of merits and dollars, we need admin 2fa login with different sso client and context.

This is surprisingly not straightforward as the library does not support this. The solution Varun and me came up with is to use another login link which will set the authconfig which will be kept in localstorage so it persists after sso redirects.

The rest is logic to read ICM merits and dollars and write the corresponding, but negative transaction once an admin onboards an user using the offices identityoffice interface